### PR TITLE
Avoid empty $thumb_path in toot_scheduled_post function

### DIFF
--- a/autopost-to-mastodon/trunk/mastodon_autopost.php
+++ b/autopost-to-mastodon/trunk/mastodon_autopost.php
@@ -386,7 +386,7 @@ class autopostToMastodon
 
 		$client = new Client($instance, $access_token);
 
-		if ( $thumb_url ) {
+		if ( $thumb_url && $thumb_path ) {
 
 			$attachment = $client->create_attachment( $thumb_path );
 


### PR DESCRIPTION
We had a scheduled post before upgrading the plugin to 3.0 and so we didn't had `autopostToMastodon-toot-thumbnail` metadata.

We got 
```
PHP Warning:  mime_content_type(): Empty filename or path in /var/www/blog/wp-content/plugins/autopost-to-mastodon/client.php on line 91
PHP Warning:  file_get_contents(): Filename cannot be empty in /var/www/blog/wp-content/plugins/autopost-to-mastodon/client.php on line 105
```

when the post has been published. The toot just contained a link to a `missing.png` image, which hasn't been pushed to mastodon.

This MR ensures that you have a non-empty `$thumb_path` in scheduled posts toot.