### PR TITLE
errors not working and optional excerpt on post

### DIFF
--- a/autopost-to-mastodon/trunk/client.php
+++ b/autopost-to-mastodon/trunk/client.php
@@ -126,9 +126,15 @@ class Client
 		);
 
 		$response = wp_remote_post( $this->getValidURL($url), $args );
+		if ( is_wp_error( $response ) ) {
+		    $error_message = $response->get_error_message();
+		    
+		} else {
 		$responseBody = wp_remote_retrieve_body($response);
-
 		return json_decode($responseBody);
+	}
+
+		return $response;
 	}
 
 	public function get($url, $data = array(), $headers = array()) {
@@ -136,11 +142,16 @@ class Client
 		    'headers' => $headers,
 		    'redirection' => 5
 		);
-
 		$response = wp_remote_get( $this->getValidURL($url), $args );
-		$responseBody = wp_remote_retrieve_body($response);
+		if ( is_wp_error( $response ) ) {
+		    $error_message = $response->get_error_message();
 
-		return json_decode($responseBody);
+		} else {
+		$responseBody = wp_remote_retrieve_body($response);
+		    return json_decode($responseBody);
+		}
+
+		return $response;
 	}
 
 	public function dump($value){

--- a/autopost-to-mastodon/trunk/mastodon_autopost.php
+++ b/autopost-to-mastodon/trunk/mastodon_autopost.php
@@ -507,6 +507,11 @@ class autopostToMastodon
 
         $excerpt_len = $toot_size - strlen($message_template) + 9 - 5;
 
+        //Replace with the excerpt of the post
+        $post_optional_excerpt = get_the_excerpt($id);
+        if (strlen($post_optional_excerpt)>0){
+            $post_content_long = $post_optional_excerpt;
+        }
         $post_excerpt = substr($post_content_long, 0, $excerpt_len);
 
         $message_template = str_replace("[excerpt]", $post_excerpt, $message_template);

--- a/autopost-to-mastodon/trunk/mastodon_autopost.php
+++ b/autopost-to-mastodon/trunk/mastodon_autopost.php
@@ -338,13 +338,13 @@ class autopostToMastodon
                     update_post_meta($id, 'autopostToMastodon-post-status', 'off');
 
                     add_action('admin_notices', 'autopostToMastodon_notice_toot_success');
-                    if (isset($toot->error)) {
+                    if (isset($toot->errors)) {
                         update_option(
                             'autopostToMastodon-notice',
                             serialize(
                                 array(
                                     'message' => '<strong>Mastodon Autopost</strong> : ' . __('Sorry, can\'t send toot !', 'autopost-to-mastodon') .
-                                    '<p><strong>' . __('Instance message', 'autopost-to-mastodon') . '</strong> : ' . $toot->error . '</p>',
+                                    '<p><strong>' . __('Instance message', 'autopost-to-mastodon') . '</strong> : ' . json_encode($toot->errors) . '</p>',
                                     'class' => 'error',
                                 )
                             )


### PR DESCRIPTION
Hi,
I have seen that there is an error with the wp_remote_post. I had a crash of apache because of some toot to a server that was down. So i handle errors. 
Furthermore I have wrote piece of code that choose the real excerpt of the post if exist. If you like we can add on the plugin, otherwise we could add a new token like [optional_excerpt] on the config.

thanks