### PR TITLE
enable users to manage_options in the config page

### DIFF
--- a/autopost-to-mastodon/trunk/mastodon_autopost.php
+++ b/autopost-to-mastodon/trunk/mastodon_autopost.php
@@ -140,7 +140,7 @@ class autopostToMastodon
         add_options_page(
             'Mastodon Autopost',
             'Mastodon Autopost',
-            'install_plugins',
+            'manage_options',
             'autopost-to-mastodon',
             array($this, 'show_configuration_page')
         );


### PR DESCRIPTION
propose to enable the users to manage the mastodon option in the config page