### PR TITLE
Add support for using categories as hashtags on posts

### DIFF
--- a/autopost-to-mastodon/trunk/form.tpl.php
+++ b/autopost-to-mastodon/trunk/form.tpl.php
@@ -125,6 +125,15 @@ define("ADVANCED_VIEW",false);
 						<input type="checkbox" id="autopost_standard" name="autopost_standard" value="on"  <?php echo ( $autopost  == 'on')?'checked':''; ?>>
 					</td>
 				</tr>
+
+				<tr style="display:<?php echo ACCOUNT_CONNECTED ? "block" : "none"?>">
+					<th scope="row">
+						<label for="cats_as_tags"><?php esc_html_e( 'Use categories as tags', 'autopost-to-mastodon' ); ?></label>
+					</th>
+					<td>
+						<input type="checkbox" id="cats_as_tags" name="cats_as_tags" value="on"  <?php echo ( $cats_as_tags  == 'on')?'checked':''; ?>>
+					</td>
+				</tr>
 			</tbody>
 		</table>
 

--- a/autopost-to-mastodon/trunk/mastodon_autopost.php
+++ b/autopost-to-mastodon/trunk/mastodon_autopost.php
@@ -479,7 +479,7 @@ class autopostToMastodon
         $message_template = str_replace("[permalink]", $post_permalink, $message_template);
 
         //Replace tags
-        $post_tagss_content = '';
+        $post_tags_content = '';
 
         $cats_as_tags = get_option('autopostToMastodon-catsAsTags', 'off');
         if ($cats_as_tags == 'on') {

--- a/autopost-to-mastodon/trunk/mastodon_autopost.php
+++ b/autopost-to-mastodon/trunk/mastodon_autopost.php
@@ -208,6 +208,12 @@ class autopostToMastodon
                             update_option('autopostToMastodon-postOnStandard', 'off');
                         }
 
+                        if (isset($_POST['cats_as_tags'])) {
+                            update_option('autopostToMastodon-catsAsTags', 'on');
+                        } else {
+                            update_option('autopostToMastodon-catsAsTags', 'off');
+                        }
+
                         update_option('autopostToMastodon-content-warning', sanitize_textarea_field($content_warning));
 
                         $account = $client->verify_credentials($token);
@@ -248,6 +254,7 @@ class autopostToMastodon
         $toot_size = get_option('autopostToMastodon-toot-size', 500);
         $content_warning = get_option('autopostToMastodon-content-warning', '');
         $autopost = get_option('autopostToMastodon-postOnStandard', 'on');
+        $cats_as_tags = get_option('autopostToMastodon-catsAsTags', 'on');
 
         include 'form.tpl.php';
     }
@@ -472,10 +479,21 @@ class autopostToMastodon
         $message_template = str_replace("[permalink]", $post_permalink, $message_template);
 
         //Replace tags
+        $post_tagss_content = '';
+
+        $cats_as_tags = get_option('autopostToMastodon-catsAsTags', 'off');
+        if ($cats_as_tags == 'on') {
+            $post_cats = get_the_category($id);
+            if (sizeof($post_cats) > 0 && $post_cats) {
+                foreach ($post_cats as $cat) {
+                    $post_tags_content = $post_tags_content . '#' . preg_replace('/\s+/', '', html_entity_decode($cat->name, ENT_COMPAT, 'UTF-8')) . ' ';
+                }
+            }
+        }
+
         $post_tags = get_the_tags($id);
 
         if (sizeof($post_tags) > 0) {
-            $post_tags_content = '';
             if ($post_tags) {
                 foreach ($post_tags as $tag) {
                     $post_tags_content = $post_tags_content . '#' . preg_replace('/\s+/', '', html_entity_decode($tag->name, ENT_COMPAT, 'UTF-8')) . ' ';


### PR DESCRIPTION
Hi,

In my usage of Mastodon_Autopost I came across the need to use categories as my hashtags.
Considering this could be useful for others, I propose this code change in order to add that useful feature.

Best regards,
Rui