### PR TITLE
Content Warnings and Alt-Text

### DIFF
--- a/autopost-to-mastodon/trunk/client.php
+++ b/autopost-to-mastodon/trunk/client.php
@@ -85,7 +85,7 @@ class Client
 		return $response;
 	}
 
-	public function create_attachment($media_path) {
+	public function create_attachment($media_path, $description="") {
 
 		$filename =basename($media_path);
 		$mime_type = mime_content_type($media_path);
@@ -101,8 +101,17 @@ class Client
 
 		$data = '--'.$boundary.$nl;
 		$data .= 'Content-Disposition: form-data; name="file"; filename="'.$filename.'"'.$nl;
-		$data .= 'Content-Type: '. $mime_type .$nl.$nl;
+		$data .= 'Content-Type: '. $mime_type .$nl;
+		$data .= $nl;
 		$data .= file_get_contents($media_path) .$nl;
+		
+		if($description) {
+		    $data .= '--'.$boundary.$nl;
+		    $data .= 'Content-Disposition: form-data; name="description"'.$nl;
+		    $data .= $nl;
+		    $data .= $description.$nl;
+		}
+		
 		$data .= '--'.$boundary.'--';
 
 		$response = $this->_post('/api/v1/media', $data, $headers);

--- a/autopost-to-mastodon/trunk/mastodon_autopost.php
+++ b/autopost-to-mastodon/trunk/mastodon_autopost.php
@@ -310,6 +310,25 @@ class autopostToMastodon
         $toot_on_mastodon_option = false;
         $cw_content = (string) get_option('autopostToMastodon-content-warning', '');
 
+        // check for cw-tags:
+        //  CW
+        //  CN
+        //  CW: $reason
+        //  CN: $reason
+        // are recognized and added to $cw_content
+        $post_tags = get_the_tags($id);
+        if ($post_tags) {
+            foreach ($post_tags as $tag) {
+                if(preg_match('/^(?:CW|CN)[: ].+/', $tag->name)) {
+                    $cw_content = $tag->name." ".$cw_content;
+                } else if($tag->name == "CN") {
+                    $cw_content = "CN (Content Notice) ".$cw_content;
+                } else if($tag->name == "CW") {
+                    $cw_content = "CW (Content Warning) ".$cw_content;
+                }
+            }
+        }
+
         $toot_on_mastodon_option = isset($_POST['toot_on_mastodon']);
 
         if ($toot_on_mastodon_option) {

--- a/autopost-to-mastodon/trunk/mastodon_autopost.php
+++ b/autopost-to-mastodon/trunk/mastodon_autopost.php
@@ -355,6 +355,10 @@ class autopostToMastodon
                     if ($thumb_url) {
 
                         $thumb_path = str_replace(get_site_url(), get_home_path(), $thumb_url);
+                        // read alt-text from thumbnail and use it as image description for mastodon
+                        $thumb = get_the_post_thumbnail($id);
+                        $thumb_alt = preg_replace('/^.*?alt="(.*?)".*$/', '$1', $thumb);
+
                         $attachment = $client->create_attachment($thumb_path);
 
                         if (is_object($attachment)) {
@@ -416,6 +420,10 @@ class autopostToMastodon
             $client = new Client($instance, $access_token);
 
             if ($thumb_url && $thumb_path) {
+
+                // read alt-text from thumbnail and use it as image description for mastodon
+                $thumb = get_the_post_thumbnail($post_id, 'medium_large');
+                $thumb_alt = preg_replace('/^.*?alt="(.*?)".*$/', '$1', $thumb);
 
                 $attachment = $client->create_attachment($thumb_path);
 


### PR DESCRIPTION
* generate content warnings from "cw: reason"-tags
* use alt-attribute as image description