### PR TITLE
unclean post content; use the_content filter

### DIFF
--- a/autopost-to-mastodon/trunk/mastodon_autopost.php
+++ b/autopost-to-mastodon/trunk/mastodon_autopost.php
@@ -598,16 +598,14 @@ class autopostToMastodon
 
         //Replace excerpt
         //Replace with the excerpt of the post
-        $post_optional_excerpt = $post->post_excerpt;
-        if (strlen($post_optional_excerpt) > 0) {
-            $post_content_long = $post_optional_excerpt;
+        if (has_excerpt($id)) {
+            $post_content_long = apply_filters('the_content', $post->post_excerpt);
         } else {
-            $post_content_long = $post->post_content;
+            $post_content_long = apply_filters('the_content', $post->post_content);
         }
         if ($wp_version[0] == "5") {
             $post_content_long = excerpt_remove_blocks($post_content_long);
         }
-        $post_content_long = strip_shortcodes($post_content_long);
         $post_content_long = html_entity_decode($post_content_long, ENT_COMPAT, 'UTF-8');
         $post_content_long = wp_strip_all_tags($post_content_long);
         //$post_content_long = str_replace("...", "",$post_content_long);


### PR DESCRIPTION
With some plugins like WP Multilang the raw post->post_content  created unclean output, like in this posts: [dresden.network/@jankosyk/110506574459924755](https://dresden.network/@jankosyk/110506574459924755). I added the `the_content` filter to the post_content.
In addition I replaced the check for an excerpt with the `has_excerpt` function.